### PR TITLE
Rename package to auth-source-keytar

### DIFF
--- a/recipes/auth-source-keytar
+++ b/recipes/auth-source-keytar
@@ -1,0 +1,1 @@
+(auth-source-keytar :repo "emacs-grammarly/auth-source-keytar" :fetcher github)

--- a/recipes/keytar
+++ b/recipes/keytar
@@ -1,1 +1,0 @@
-(keytar :repo "emacs-grammarly/keytar" :fetcher github)


### PR DESCRIPTION
I am renaming package `keytar` to `auth-source-keytar`. This PR updates it. :)