### PR TITLE
Update repo address

### DIFF
--- a/recipes/company-box
+++ b/recipes/company-box
@@ -1,4 +1,4 @@
 (company-box
- :repo "jcs090218/company-box"
+ :repo "elp-revive/company-box"
  :fetcher github
  :files (:defaults "images"))

--- a/recipes/origami
+++ b/recipes/origami
@@ -1,1 +1,1 @@
-(origami :repo "emacs-origami/origami.el" :fetcher github)
+(origami :repo "elp-revive/origami.el" :fetcher github)


### PR DESCRIPTION
I have moved `origami` and `company-box` under a org `elp-revive`.

Update recipes for these packages.