### PR TITLE
Leave keytar to MELPA

### DIFF
--- a/recipes/auth-source-keytar
+++ b/recipes/auth-source-keytar
@@ -1,1 +1,0 @@
-(auth-source-keytar :repo "emacs-grammarly/auth-source-keytar" :fetcher github)

--- a/recipes/keytar
+++ b/recipes/keytar
@@ -1,1 +1,0 @@
-(keytar :repo "emacs-grammarly/keytar" :fetcher github)


### PR DESCRIPTION
I am going to let keytar packages to MELPA, so it's easier for me to manage these packages in one archive.